### PR TITLE
Allow public access to UseStreamDeck and IStreamDeckActionRegistry

### DIFF
--- a/src/SharpDeck/Extensions/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/SharpDeck/Extensions/DependencyInjection/ServiceCollectionExtensions.cs
@@ -29,7 +29,7 @@ namespace SharpDeck.Extensions.DependencyInjection
 
                 // Actions and interactivity.
                 .AddSingleton<IDynamicProfileFactory, DynamicProfileFactory>()
-                .AddSingleton(provider =>
+                .AddSingleton<IStreamDeckActionRegistry>(provider =>
                 {
                     // Construct the default action registry.
                     var actionRegistry = ActivatorUtilities.CreateInstance<StreamDeckActionRegistry>(provider);

--- a/src/SharpDeck/Extensions/Hosting/HostBuilderExtensions.cs
+++ b/src/SharpDeck/Extensions/Hosting/HostBuilderExtensions.cs
@@ -33,7 +33,7 @@ namespace SharpDeck.Extensions.Hosting
         /// </summary>
         /// <param name="builder">The host builder.</param>
         /// <returns>The host builder for chaining.</returns>
-        private static IHostBuilder UseStreamDeck(this IHostBuilder builder)
+        public static IHostBuilder UseStreamDeck(this IHostBuilder builder)
             => builder.ConfigureServices(services =>
             {
                 services

--- a/src/SharpDeck/Hosting/StreamDeckPluginHostLifetime.cs
+++ b/src/SharpDeck/Hosting/StreamDeckPluginHostLifetime.cs
@@ -16,9 +16,12 @@ namespace SharpDeck.Hosting
         /// </summary>
         /// <param name="connection">The connection.</param>
         /// <param name="actionRegistry">The action registry.</param>
-        public StreamDeckPluginHostLifetime(StreamDeckWebSocketConnection connection, StreamDeckActionRegistry actionRegistry)
+        public StreamDeckPluginHostLifetime(StreamDeckWebSocketConnection connection, IStreamDeckActionRegistry actionRegistry)
         {
-            actionRegistry.IsEnabled = true;
+            if (actionRegistry is StreamDeckActionRegistry registry)
+            {
+                registry.IsEnabled = true;
+            }
             this.Connection = connection;
         }
 


### PR DESCRIPTION
I would like to propose 2 changes:
- Allow public access to UseStreamDeck. This would be very beneficial to some complex setup such as integrating to WPF and reuse the ServiceProvider. Having direct access to UseStreamDeck means we can have more control on IHost instance to allow integration with more scenario.
- Register IStreamDeckActionRegistry to the service provider instead of StreamDeckActionRegistry. This allows library consumers to call RegisterAll on specific assemblies. This would be required to register StreamDeckAction in referenced library projects.