### PR TITLE
Makes the RegistrationInfo accessible via IStreamDeckConnection

### DIFF
--- a/src/SharpDeck/Connectivity/IStreamDeckConnection.cs
+++ b/src/SharpDeck/Connectivity/IStreamDeckConnection.cs
@@ -112,6 +112,11 @@ namespace SharpDeck.Connectivity
         event EventHandler<ActionEventArgs<AppearancePayload>> WillDisappear;
 
         /// <summary>
+        /// Gets the information about the connection.
+        /// </summary>
+        RegistrationInfo Info { get; }
+
+        /// <summary>
         /// Requests the persistent global data stored for the plugin.
         /// </summary>
         /// <param name="cancellationToken">The optional cancellation token.</param>


### PR DESCRIPTION
The underlying StreamDeckWebSocketConnection holds the information about the registration info (Stream Deck and device information). However, it is not exposed in the interface.

(cherry picked from commit 670e755a9de896386d45d82091791b1f1f29dbf5)